### PR TITLE
Read 16-bit CS16 stream format from device instead of using CU8

### DIFF
--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -490,34 +490,4 @@ int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **str
 #endif
 }
 
-int read_samples_cu8(SoapySDRDevice *dev, SoapySDRStream *stream, uint8_t *buf, int len)
-{
-	void *buffs[] = {buf};
-	int flags = 0;
-	long long timeNs = 0;
-	long timeoutNs = 1000000;
-	int bytes_read, r;
-
-	r = SoapySDRDevice_readStream(dev, stream, buffs, len, &flags, &timeNs, timeoutNs);
-
-	//fprintf(stderr, "readStream ret=%d, flags=%d, timeNs=%lld\n", r, flags, timeNs);
-	if (r >= 0) {
-		// r is number of elements read, elements=complex pairs of 8-bits, so buffer length in bytes is twice
-		bytes_read = r * 2;
-
-		// Convert CS8 to CU8, back to RTL-SDR native format!
-		// TODO: see https://github.com/pothosware/SoapyRTLSDR/issues/15
-		// TODO: or use "direct buffer access API"?
-		// TODO: or2, remove +127 here and -127 in rtlsdr_callback! back and forth too many times (-127 in SoapyRTLSDR)
-		for(int i = 0; i < bytes_read; ++i) {
-			buf[i] += 127;
-		}
-		return bytes_read;
-	} else {
-		// error code
-		return r;
-	}
-}
-
-
 // vim: tabstop=8:softtabstop=8:shiftwidth=8:noexpandtab

--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -429,7 +429,7 @@ int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **str
 	show_device_info(dev);
 
 	SoapySDRKwargs streamArgs = {};
-	if (SoapySDRDevice_setupStream(dev, streamOut, SOAPY_SDR_RX, SOAPY_SDR_CS8, NULL, 0, &streamArgs) != 0) {
+	if (SoapySDRDevice_setupStream(dev, streamOut, SOAPY_SDR_RX, SOAPY_SDR_CS16, NULL, 0, &streamArgs) != 0) {
 		fprintf(stderr, "SoapySDRDevice_setupStream failed\n");
 		return -3;
 	}

--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -435,6 +435,7 @@ int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **str
 	}
 
 	// Restore stdout back to stdout
+	fflush(stdout);
 	dup2(tmp_stdout, STDOUT_FILENO);
 
 	*devOut = dev;

--- a/src/convenience/convenience.h
+++ b/src/convenience/convenience.h
@@ -156,15 +156,4 @@ int verbose_reset_buffer(SoapySDRDevice *dev);
 
 int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **streamOut);
 
-/*!
- * Read samples as Complex Unsigned 8-bit (CU8) pairs
- *
- * \param dev the device handle
- * \param stream the stream handle
- * \param buf buffer to read into
- * \param len maximum number of elements in buf
- * \return number of bytes read, or negative if an error
- */
-int read_samples_cu8(SoapySDRDevice *dev, SoapySDRStream *stream, uint8_t *buf, int len);
-
 #endif /*__CONVENIENCE_H*/


### PR DESCRIPTION
#8 Support for non-CS8 stream formats (CS16, CF32) for >8-bit devices such as bladeRF

continuation of https://github.com/rxseger/rx_tools/pull/11