### PR TITLE
added cmake build, tweaks for msvc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,72 @@
+########################################################################
+# Project setup
+########################################################################
+cmake_minimum_required(VERSION 2.8.0)
+project(rx_tools C)
+
+#local include directories first
+include_directories(${PROJECT_SOURCE_DIR}/src/convenience)
+
+#include local cmake modules
+list(APPEND CMAKE_MODULE_PATH ${PROJECT_SOURCE_DIR}/cmake)
+
+########################################################################
+# Dependencies
+########################################################################
+find_package(SoapySDR "0.5" NO_MODULE)
+if (NOT SoapySDR_FOUND)
+    message(FATAL_ERROR "Soapy SDR development files not found...")
+endif ()
+include_directories(${SoapySDR_INCLUDE_DIRS})
+list(APPEND RX_TOOLS_LIBS ${SoapySDR_LIBRARIES})
+
+#link with libm when available
+find_library(
+    MATH_LIBRARIES NAMES m
+    PATHS /usr/lib /usr/lib64
+)
+if (MATH_LIBRARIES)
+    list(APPEND RX_TOOLS_LIBS ${MATH_LIBRARIES})
+endif ()
+
+#link with pthreads
+set(THREADS_USE_PTHREADS_WIN32 true)
+find_package(Threads)
+if (NOT THREADS_FOUND)
+    message(FATAL_ERROR "pthreads development files not found...")
+endif ()
+include_directories(${THREADS_PTHREADS_INCLUDE_DIR})
+list(APPEND RX_TOOLS_LIBS ${CMAKE_THREAD_LIBS_INIT})
+message(STATUS "THREADS_PTHREADS_INCLUDE_DIR: ${THREADS_PTHREADS_INCLUDE_DIR}")
+message(STATUS "CMAKE_THREAD_LIBS_INIT: ${CMAKE_THREAD_LIBS_INIT}")
+
+#windows getopt compatibility
+if (WIN32)
+    include_directories(${PROJECT_SOURCE_DIR}/src/getopt)
+    list(APPEND COMMON_SOURCES src/getopt/getopt.c)
+endif ()
+
+########################################################################
+# Helper library
+########################################################################
+set(CMAKE_POSITION_INDEPENDENT_CODE TRUE)
+list(APPEND COMMON_SOURCES src/convenience/convenience.c)
+add_library(common STATIC ${COMMON_SOURCES})
+list(APPEND RX_TOOLS_LIBS common)
+
+########################################################################
+# Build executables
+########################################################################
+add_executable(rx_fm src/rtl_fm.c)
+target_link_libraries(rx_fm ${RX_TOOLS_LIBS})
+
+add_executable(rx_power src/rtl_power.c)
+target_link_libraries(rx_power ${RX_TOOLS_LIBS})
+
+add_executable(rx_sdr src/rtl_sdr.c)
+target_link_libraries(rx_sdr ${RX_TOOLS_LIBS})
+
+########################################################################
+# Install executables
+########################################################################
+install(TARGETS rx_fm rx_power rx_sdr DESTINATION bin)

--- a/cmake/FindThreads.cmake
+++ b/cmake/FindThreads.cmake
@@ -1,0 +1,246 @@
+# Updated FindThreads.cmake that supports pthread-win32
+# Downloaded from http://www.vtk.org/Bug/bug_view_advanced_page.php?bug_id=6399
+
+# - This module determines the thread library of the system.
+#
+# The following variables are set
+#  CMAKE_THREAD_LIBS_INIT     - the thread library
+#  CMAKE_USE_SPROC_INIT       - are we using sproc?
+#  CMAKE_USE_WIN32_THREADS_INIT - using WIN32 threads?
+#  CMAKE_USE_PTHREADS_INIT    - are we using pthreads
+#  CMAKE_HP_PTHREADS_INIT     - are we using hp pthreads
+#
+# If use of pthreads-win32 is desired, the following variables
+# can be set.
+#
+#  THREADS_USE_PTHREADS_WIN32 -
+#    Setting this to true searches for the pthreads-win32
+#    port (since CMake 2.8.0)
+#
+#  THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME
+#      C  = no exceptions (default)
+#         (NOTE: This is the default scheme on most POSIX thread
+#          implementations and what you should probably be using)
+#      CE = C++ Exception Handling
+#      SE = Structure Exception Handling (MSVC only)
+#      (NOTE: Changing this option from the default may affect
+#       the portability of your application.  See pthreads-win32
+#       documentation for more details.)
+#
+#======================================================
+# Example usage where threading library
+# is provided by the system:
+#
+#   find_package(Threads REQUIRED)
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${CMAKE_THREAD_LIBS_INIT})
+#
+# Example usage if pthreads-win32 is desired on Windows
+# or a system provided thread library:
+#
+#   set(THREADS_USE_PTHREADS_WIN32 true)
+#   find_package(Threads REQUIRED)
+#   include_directories(${THREADS_PTHREADS_INCLUDE_DIR})
+#
+#   add_executable(foo foo.cc)
+#   target_link_libraries(foo ${CMAKE_THREAD_LIBS_INIT})
+#
+
+INCLUDE (CheckIncludeFiles)
+INCLUDE (CheckLibraryExists)
+SET(Threads_FOUND FALSE)
+
+IF(WIN32 AND NOT CYGWIN AND THREADS_USE_PTHREADS_WIN32)
+  SET(_Threads_ptwin32 true)
+ENDIF()
+
+# Do we have sproc?
+IF(CMAKE_SYSTEM MATCHES IRIX)
+  CHECK_INCLUDE_FILES("sys/types.h;sys/prctl.h"  CMAKE_HAVE_SPROC_H)
+ENDIF()
+
+IF(CMAKE_HAVE_SPROC_H)
+  # We have sproc
+  SET(CMAKE_USE_SPROC_INIT 1)
+
+ELSEIF(_Threads_ptwin32)
+
+  IF(NOT DEFINED THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME)
+    # Assign the default scheme
+    SET(THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME "C")
+  ELSE()
+    # Validate the scheme specified by the user
+    IF(NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "C" AND
+       NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "CE" AND
+       NOT THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+         MESSAGE(FATAL_ERROR "See documentation for FindPthreads.cmake, only C, CE, and SE modes are allowed")
+    ENDIF()
+    IF(NOT MSVC AND THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+      MESSAGE(FATAL_ERROR "Structured Exception Handling is only allowed for MSVC")
+    ENDIF(NOT MSVC AND THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME STREQUAL "SE")
+  ENDIF()
+
+  FIND_PATH(THREADS_PTHREADS_INCLUDE_DIR pthread.h)
+
+  # Determine the library filename
+  IF(MSVC)
+    SET(_Threads_pthreads_libname
+        pthreadV${THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME}2)
+  ELSEIF(MINGW)
+    SET(_Threads_pthreads_libname
+        pthreadG${THREADS_PTHREADS_WIN32_EXCEPTION_SCHEME}2)
+  ELSE()
+    MESSAGE(FATAL_ERROR "This should never happen")
+  ENDIF()
+
+  # Use the include path to help find the library if possible
+  SET(_Threads_lib_paths "")
+  IF(THREADS_PTHREADS_INCLUDE_DIR)
+     GET_FILENAME_COMPONENT(_Threads_root_dir
+                            ${THREADS_PTHREADS_INCLUDE_DIR} PATH)
+     SET(_Threads_lib_paths ${_Threads_root_dir}/lib)
+  ENDIF()
+  FIND_LIBRARY(THREADS_PTHREADS_WIN32_LIBRARY
+               NAMES ${_Threads_pthreads_libname}
+               PATHS ${_Threads_lib_paths}
+               DOC "The Portable Threads Library for Win32"
+               NO_SYSTEM_PATH
+               )
+
+  IF(THREADS_PTHREADS_INCLUDE_DIR AND THREADS_PTHREADS_WIN32_LIBRARY)
+    MARK_AS_ADVANCED(THREADS_PTHREADS_INCLUDE_DIR)
+    SET(CMAKE_THREAD_LIBS_INIT ${THREADS_PTHREADS_WIN32_LIBRARY})
+    SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+    SET(Threads_FOUND TRUE)
+  ENDIF()
+
+  MARK_AS_ADVANCED(THREADS_PTHREADS_WIN32_LIBRARY)
+
+ELSE()
+  # Do we have pthreads?
+  CHECK_INCLUDE_FILES("pthread.h" CMAKE_HAVE_PTHREAD_H)
+  IF(CMAKE_HAVE_PTHREAD_H)
+
+    #
+    # We have pthread.h
+    # Let's check for the library now.
+    #
+    SET(CMAKE_HAVE_THREADS_LIBRARY)
+    IF(NOT THREADS_HAVE_PTHREAD_ARG)
+
+      # Do we have -lpthreads
+      CHECK_LIBRARY_EXISTS(pthreads pthread_create "" CMAKE_HAVE_PTHREADS_CREATE)
+      IF(CMAKE_HAVE_PTHREADS_CREATE)
+        SET(CMAKE_THREAD_LIBS_INIT "-lpthreads")
+        SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+        SET(Threads_FOUND TRUE)
+      ENDIF()
+
+      # Ok, how about -lpthread
+      CHECK_LIBRARY_EXISTS(pthread pthread_create "" CMAKE_HAVE_PTHREAD_CREATE)
+      IF(CMAKE_HAVE_PTHREAD_CREATE)
+        SET(CMAKE_THREAD_LIBS_INIT "-lpthread")
+        SET(Threads_FOUND TRUE)
+        SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+      ENDIF()
+
+      IF(CMAKE_SYSTEM MATCHES "SunOS.*")
+        # On sun also check for -lthread
+        CHECK_LIBRARY_EXISTS(thread thr_create "" CMAKE_HAVE_THR_CREATE)
+        IF(CMAKE_HAVE_THR_CREATE)
+          SET(CMAKE_THREAD_LIBS_INIT "-lthread")
+          SET(CMAKE_HAVE_THREADS_LIBRARY 1)
+          SET(Threads_FOUND TRUE)
+        ENDIF()
+      ENDIF(CMAKE_SYSTEM MATCHES "SunOS.*")
+
+    ENDIF(NOT THREADS_HAVE_PTHREAD_ARG)
+
+    IF(NOT CMAKE_HAVE_THREADS_LIBRARY)
+      # If we did not found -lpthread, -lpthread, or -lthread, look for -pthread
+      IF("THREADS_HAVE_PTHREAD_ARG" MATCHES "^THREADS_HAVE_PTHREAD_ARG")
+        MESSAGE(STATUS "Check if compiler accepts -pthread")
+        TRY_RUN(THREADS_PTHREAD_ARG THREADS_HAVE_PTHREAD_ARG
+          ${CMAKE_BINARY_DIR}
+          ${CMAKE_ROOT}/Modules/CheckForPthreads.c
+          CMAKE_FLAGS -DLINK_LIBRARIES:STRING=-pthread
+          COMPILE_OUTPUT_VARIABLE OUTPUT)
+
+        IF(THREADS_HAVE_PTHREAD_ARG)
+          IF(THREADS_PTHREAD_ARG MATCHES "^2$")
+            SET(Threads_FOUND TRUE)
+            MESSAGE(STATUS "Check if compiler accepts -pthread - yes")
+          ELSE()
+            MESSAGE(STATUS "Check if compiler accepts -pthread - no")
+            FILE(APPEND
+              ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+              "Determining if compiler accepts -pthread returned ${THREADS_PTHREAD_ARG} instead of 2. The compiler had the following output:\n${OUTPUT}\n\n")
+          ENDIF()
+        ELSE()
+          MESSAGE(STATUS "Check if compiler accepts -pthread - no")
+          FILE(APPEND
+            ${CMAKE_BINARY_DIR}${CMAKE_FILES_DIRECTORY}/CMakeError.log
+            "Determining if compiler accepts -pthread failed with the following output:\n${OUTPUT}\n\n")
+        ENDIF()
+
+      ENDIF("THREADS_HAVE_PTHREAD_ARG" MATCHES "^THREADS_HAVE_PTHREAD_ARG")
+
+      IF(THREADS_HAVE_PTHREAD_ARG)
+        SET(Threads_FOUND TRUE)
+        SET(CMAKE_THREAD_LIBS_INIT "-pthread")
+      ENDIF()
+
+    ENDIF(NOT CMAKE_HAVE_THREADS_LIBRARY)
+  ENDIF(CMAKE_HAVE_PTHREAD_H)
+ENDIF()
+
+IF(CMAKE_THREAD_LIBS_INIT)
+  SET(CMAKE_USE_PTHREADS_INIT 1)
+  SET(Threads_FOUND TRUE)
+ENDIF()
+
+IF(CMAKE_SYSTEM MATCHES "Windows"
+   AND NOT THREADS_USE_PTHREADS_WIN32)
+  SET(CMAKE_USE_WIN32_THREADS_INIT 1)
+  SET(Threads_FOUND TRUE)
+ENDIF()
+
+IF(CMAKE_USE_PTHREADS_INIT)
+  IF(CMAKE_SYSTEM MATCHES "HP-UX-*")
+    # Use libcma if it exists and can be used.  It provides more
+    # symbols than the plain pthread library.  CMA threads
+    # have actually been deprecated:
+    #   http://docs.hp.com/en/B3920-90091/ch12s03.html#d0e11395
+    #   http://docs.hp.com/en/947/d8.html
+    # but we need to maintain compatibility here.
+    # The CMAKE_HP_PTHREADS setting actually indicates whether CMA threads
+    # are available.
+    CHECK_LIBRARY_EXISTS(cma pthread_attr_create "" CMAKE_HAVE_HP_CMA)
+    IF(CMAKE_HAVE_HP_CMA)
+      SET(CMAKE_THREAD_LIBS_INIT "-lcma")
+      SET(CMAKE_HP_PTHREADS_INIT 1)
+      SET(Threads_FOUND TRUE)
+    ENDIF(CMAKE_HAVE_HP_CMA)
+    SET(CMAKE_USE_PTHREADS_INIT 1)
+  ENDIF()
+
+  IF(CMAKE_SYSTEM MATCHES "OSF1-V*")
+    SET(CMAKE_USE_PTHREADS_INIT 0)
+    SET(CMAKE_THREAD_LIBS_INIT )
+  ENDIF()
+
+  IF(CMAKE_SYSTEM MATCHES "CYGWIN_NT*")
+    SET(CMAKE_USE_PTHREADS_INIT 1)
+    SET(Threads_FOUND TRUE)
+    SET(CMAKE_THREAD_LIBS_INIT )
+    SET(CMAKE_USE_WIN32_THREADS_INIT 0)
+  ENDIF()
+ENDIF(CMAKE_USE_PTHREADS_INIT)
+
+INCLUDE(FindPackageHandleStandardArgs)
+IF(_Threads_ptwin32)
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Threads DEFAULT_MSG
+    THREADS_PTHREADS_WIN32_LIBRARY THREADS_PTHREADS_INCLUDE_DIR)
+ELSE()
+  FIND_PACKAGE_HANDLE_STANDARD_ARGS(Threads DEFAULT_MSG Threads_FOUND)
+ENDIF()

--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -19,6 +19,7 @@
  * todo: use strtol for more flexible int parsing
  * */
 
+#include "convenience.h"
 #include <string.h>
 #include <stdio.h>
 #include <stdlib.h>
@@ -36,6 +37,16 @@
 
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Formats.h>
+
+#ifdef _MSC_VER
+struct tm *localtime_r (const time_t *timer, struct tm *result)
+{
+    struct tm *local_result = localtime (timer);
+    if (local_result == NULL || result == NULL) return NULL;
+    memcpy (result, local_result, sizeof (result));
+    return result;
+}
+#endif
 
 double atofs(char *s)
 /* standard suffixes */
@@ -156,7 +167,7 @@ int verbose_set_frequency(SoapySDRDevice *dev, uint32_t frequency)
 {
 	int r;
 
-	SoapySDRKwargs args = {};
+	SoapySDRKwargs args = {0};
 	r = (int)SoapySDRDevice_setFrequency(dev, SOAPY_SDR_RX, 0, (double)frequency, &args);
 	if (r != 0) {
 		fprintf(stderr, "WARNING: Failed to set center freq.\n");
@@ -434,7 +445,7 @@ int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **str
 	char vendor[256], product[256], serial[256];
 	SoapySDRDevice *dev = NULL;
 
-	SoapySDRKwargs args = {}; // https://github.com/pothosware/SoapySDR/wiki/C_API_Example shows passing NULL, but crashes on 0.4.3 - this works
+	SoapySDRKwargs args = {0}; // https://github.com/pothosware/SoapySDR/wiki/C_API_Example shows passing NULL, but crashes on 0.4.3 - this works
 	SoapySDRKwargs *results = SoapySDRDevice_enumerate(&args, &device_count);
 	if (!device_count) {
 		fprintf(stderr, "No supported devices found.\n");
@@ -474,7 +485,7 @@ int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **str
 
 	show_device_info(dev);
 
-	SoapySDRKwargs streamArgs = {};
+	SoapySDRKwargs streamArgs = {0};
 	if (SoapySDRDevice_setupStream(dev, streamOut, SOAPY_SDR_RX, SOAPY_SDR_CS16, NULL, 0, &streamArgs) != 0) {
 		fprintf(stderr, "SoapySDRDevice_setupStream failed\n");
 		return -3;

--- a/src/convenience/convenience.h
+++ b/src/convenience/convenience.h
@@ -17,6 +17,21 @@
 #ifndef __CONVENIENCE_H
 #define __CONVENIENCE_H
 
+#ifdef _MSC_VER
+#define STDOUT_FILENO fileno(stdout)
+#define STDERR_FILENO fileno(stderr)
+#define bool _Bool
+#define false 0
+#define true 1
+#define bzero(b,len) (memset((b), '\0', (len)), (void) 0)
+#define strcasecmp _stricmp
+#include <time.h>
+struct tm *localtime_r (const time_t *timer, struct tm *result);
+#endif
+
+#include <stdint.h>
+#include <SoapySDR/Device.h>
+
 
 /* a collection of user friendly tools */
 

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -72,6 +72,7 @@
 #include <math.h>
 #include <pthread.h>
 
+#include "convenience.h"
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Formats.h>
 
@@ -1031,7 +1032,7 @@ static void *controller_thread_fn(void *arg)
 	verbose_set_sample_rate(dongle.dev, dongle.rate);
 	fprintf(stderr, "Output at %u Hz.\n", demod.rate_in/demod.post_downsample);
 
-	SoapySDRKwargs args = {};
+	SoapySDRKwargs args = {0};
 	while (!do_exit) {
 		safe_cond_wait(&s->hop, &s->hop_m);
 		if (s->freq_len <= 1) {

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -62,6 +62,7 @@
 #include <math.h>
 #include <pthread.h>
 
+#include "convenience.h"
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Formats.h>
 
@@ -545,7 +546,7 @@ void retune(SoapySDRDevice *d, SoapySDRStream *s, int64_t freq)
 {
 	int n_read;
 
-	SoapySDRKwargs args = {};
+	SoapySDRKwargs args = {0};
 	SoapySDRDevice_setFrequency(d, SOAPY_SDR_RX, 0, (double)freq, &args);
 	// TODO: check if failed to set frequency?
 
@@ -823,7 +824,7 @@ int main(int argc, char **argv)
 	time_t time_now;
 	time_t exit_time = 0;
 	char t_str[50];
-	struct tm cal_time = {};
+	struct tm cal_time = {0};
 	double (*window_fn)(int, int) = rectangle;
 	freq_optarg = "";
 

--- a/src/rtl_sdr.c
+++ b/src/rtl_sdr.c
@@ -31,6 +31,7 @@
 #include "getopt/getopt.h"
 #endif
 
+#include "convenience.h"
 #include <SoapySDR/Device.h>
 #include <SoapySDR/Formats.h>
 
@@ -235,7 +236,7 @@ int main(int argc, char **argv)
 
 	if (true || sync_mode) {
 		fprintf(stderr, "Reading samples in sync mode...\n");
-		SoapySDRKwargs args = {};
+		SoapySDRKwargs args = {0};
 		if (SoapySDRDevice_activateStream(dev, stream, 0, 0, 0) != 0) {
 			fprintf(stderr, "Failed to activate stream\n");
                         exit(1);


### PR DESCRIPTION
* CMakeLists.txt to build executables with cmake
* cmake/FindThreads.cmake for pthreads win32 support
* src/convenience/convenience.h - msvc compat additions
* misc changes: switched to {0} for zero initialization

I'm looking to add this project to [my PothosSDR windows build](https://github.com/pothosware/PothosSDR/wiki). Thats the main reason for the CMakeLists and the MSVC compat stuff. I didn't test on hardware but it compiles. The only real change outside of the compatibility ifdefs is the zero initialization: ``= {}`` vs ``= {0}``. I think they both work, but the first wont compile for MSVC.