### PR TITLE
rx_power: use int64_t instead of long, 32-bit arch compat. Closes GH-33

### DIFF
--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -92,7 +92,7 @@ struct tuning_state
 	int64_t freq;
 	int rate;
 	int bin_e;
-	long *avg;  /* length == 2^bin_e */
+	int64_t *avg;  /* length == 2^bin_e */
 	int samples;
 	int downsample;
 	int downsample_passes;  /* for the recursive filter */
@@ -404,19 +404,19 @@ void rms_power(struct tuning_state *ts)
 	int i, s;
 	int16_t *buf = ts->buf16;
 	int buf_len = ts->buf_len;
-	long p, t;
+	int64_t p, t;
 	double dc, err;
 
 	p = t = 0L;
 	for (i=0; i<buf_len; i++) {
 		s = (int)buf[i];
-		t += (long)s;
-		p += (long)(s * s);
+		t += (int64_t)s;
+		p += (int64_t)s * (int64_t)s;
 	}
 	/* correct for dc offset in squares */
 	dc = (double)t / (double)buf_len;
 	err = t * 2 * dc - dc * dc * buf_len;
-	p -= (long)round(err);
+	p -= (int64_t)round(err);
 
 	if (!peak_hold) {
 		ts->avg[0] += p;
@@ -513,7 +513,7 @@ void frequency_range(char *arg, double crop)
 		ts->crop = crop;
 		ts->downsample = downsample;
 		ts->downsample_passes = downsample_passes;
-		ts->avg = (long*)malloc((1<<bin_e) * sizeof(long));
+		ts->avg = (int64_t*)malloc((1<<bin_e) * sizeof(int64_t));
 		if (!ts->avg) {
 			fprintf(stderr, "Error: malloc.\n");
 			exit(1);
@@ -609,11 +609,11 @@ void remove_dc(int16_t *data, int length)
 {
 	int i;
 	int16_t ave;
-	long sum = 0L;
+	int64_t sum = 0L;
 	for (i=0; i < length; i+=2) {
 		sum += data[i];
 	}
-	ave = (int16_t)(sum / (long)(length));
+	ave = (int16_t)(sum / (int64_t)(length));
 	if (ave == 0) {
 		return;}
 	for (i=0; i < length; i+=2) {
@@ -659,10 +659,10 @@ void downsample_iq(int16_t *data, int length)
 	//remove_dc(data+1, length-1);
 }
 
-long real_conj(int16_t real, int16_t imag)
+int64_t real_conj(int16_t real, int16_t imag)
 /* real(n * conj(n)) */
 {
-	return ((long)real*(long)real + (long)imag*(long)imag);
+	return ((int64_t)real*(int64_t)real + (int64_t)imag*(int64_t)imag);
 }
 
 void scanner(void)
@@ -771,7 +771,7 @@ void scanner(void)
 void csv_dbm(struct tuning_state *ts)
 {
 	int i, len, ds, i1, i2, bw2, bin_count;
-	long tmp;
+	int64_t tmp;
 	double dbm;
 	len = 1 << ts->bin_e;
 	ds = ts->downsample;


### PR DESCRIPTION
https://github.com/rxseger/rx_tools/issues/33 rx_power: overflows on 32-bit architectures with >2.1 GHz frequencies (NaN on Raspberry Pi with HackRF)

continuation of #21 rx_power: stops at 2.1461 GHz, would like to scan up to 6 GHz with HackRF (>32-bit frequencies)