### PR TITLE
don't do sizeof pointer

### DIFF
--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -44,7 +44,7 @@ struct tm *localtime_r (const time_t *timer, struct tm *result)
 {
     struct tm *local_result = localtime (timer);
     if (local_result == NULL || result == NULL) return NULL;
-    memcpy (result, local_result, sizeof (result));
+    memcpy (result, local_result, sizeof (struct tm));
     return result;
 }
 


### PR DESCRIPTION
Do sizeof the whole struct

Was crashing on my win64 machine the rx_power.exe that came with the PothosSDR.  