### PR TITLE
Add -a antenna support

### DIFF
--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -118,6 +118,7 @@ struct dongle_state
 	int	  direct_sampling;
 	int	  mute;
 	struct demod_state *demod_target;
+	char *antenna;
 };
 
 struct demod_state
@@ -230,6 +231,7 @@ void usage(void)
 		"\t	offset: enable offset tuning (only e4000 tuner)\n"
 		"\t	wav:    generate WAV header\n"
 		"\t[-q dc_avg_factor for option rdc (default: 9)]\n"
+		"\t[-a Antenna selection (default: not set)]\n"
 		"\tfilename ('-' means stdout)\n"
 		"\t	omitting the filename also uses stdout\n\n"
 		"Experimental options:\n"
@@ -1210,8 +1212,11 @@ int main(int argc, char **argv)
 	controller_init(&controller);
 	dongle.dev_query = "";
 
-	while ((opt = getopt(argc, argv, "d:f:g:s:b:l:L:o:t:r:p:E:q:F:A:M:c:h:w:v")) != -1) {
+	while ((opt = getopt(argc, argv, "a:d:f:g:s:b:l:L:o:t:r:p:E:q:F:A:M:c:h:w:v")) != -1) {
 		switch (opt) {
+		case 'a':
+			dongle.antenna = optarg;
+			break;
 		case 'd':
 			dongle.dev_query = optarg;
 			break;
@@ -1402,6 +1407,14 @@ int main(int argc, char **argv)
 	}
 
 	SoapySDRDevice_setGainMode(dongle.dev, SOAPY_SDR_RX, 0, rtlagc);
+
+	if (strlen(dongle.antenna) > 0) {
+		r = SoapySDRDevice_setAntenna(dongle.dev, SOAPY_SDR_RX, 0, dongle.antenna);
+		if (r != 0) {
+			fprintf(stderr, "Failed to set antenna: '%s'.\n", dongle.antenna);
+			exit(1);
+		}
+	}
 
 	verbose_ppm_set(dongle.dev, dongle.ppm_error);
 

--- a/src/rtl_sdr.c
+++ b/src/rtl_sdr.c
@@ -60,6 +60,7 @@ void usage(void)
 		"\t[-F output format, CU8|CS8|CS16|CF32 (default: CU8)]\n"
 		"\t[-S force sync output (default: async)]\n"
 		"\t[-D direct_sampling_mode, 0 (default/off), 1 (I), 2 (Q), 3 (no-mod)]\n"
+		"\t[-a antenna (default: not set)]\n"
 		"\tfilename (a '-' dumps samples to stdout)\n\n");
 	exit(1);
 }
@@ -104,9 +105,13 @@ int main(int argc, char **argv)
 	uint32_t samp_rate = DEFAULT_SAMPLE_RATE;
 	uint32_t out_block_size = DEFAULT_BUF_LENGTH;
 	char *output_format = SOAPY_SDR_CU8;
+	char *antenna = "";
 
-	while ((opt = getopt(argc, argv, "d:f:g:s:b:n:p:D:SF:")) != -1) {
+	while ((opt = getopt(argc, argv, "a:d:f:g:s:b:n:p:D:SF:")) != -1) {
 		switch (opt) {
+		case 'a':
+			antenna = optarg;
+			break;
 		case 'd':
 			dev_query = optarg;
 			break;
@@ -219,6 +224,14 @@ int main(int argc, char **argv)
 	} else {
 		/* Enable manual gain */
 		verbose_gain_str_set(dev, gain_str);
+	}
+
+	if (strlen(antenna) > 0) {
+		r = SoapySDRDevice_setAntenna(dev, SOAPY_SDR_RX, 0, antenna);
+		if (r != 0) {
+			fprintf(stderr, "Failed to set antenna: '%s'.\n", antenna);
+			exit(1);
+		}
 	}
 
 	verbose_ppm_set(dev, ppm_error);


### PR DESCRIPTION
Add missing support for selecting an antenna via the command line. This is required for devices like LimeSDR-USB, LimeSDR-Mini or other multi-antenna systems.
