### PR TITLE
Add zero option to rx_fm

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,6 +3,7 @@
 ########################################################################
 cmake_minimum_required(VERSION 2.8.0)
 project(rx_tools C)
+set(CMAKE_C_STANDARD 99)
 
 #local include directories first
 include_directories(${PROJECT_SOURCE_DIR}/src/convenience)


### PR DESCRIPTION
This adds an option for rx_fm to emit zeros when the squelch is active. I need this because some programs require a constant audio stream when I'm piping rx_fm's `stdout` to their `stdin`.