### PR TITLE
add -t option to set SDR options

### DIFF
--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -360,6 +360,37 @@ int verbose_reset_buffer(SoapySDRDevice *dev)
 	return r;
 }
 
+int verbose_settings(SoapySDRDevice *dev, const char *sdr_settings)
+{
+	char *copied, *cursor, *pair, *equals;
+	int status = 0;
+
+	copied = strdup(sdr_settings);
+	cursor = copied;
+	while ((pair = strsep(&cursor, ",")) != NULL) {
+		char *key, *value;
+
+		equals = strchr(pair, '=');
+		if (equals) {
+			key = pair;
+			*equals = '\0';
+			value = equals + 1;
+		} else {
+			key = pair;
+			value = "";
+		}
+		fprintf(stderr, "set key=|%s|, value=|%s|\n", key, value);
+		if(SoapySDRDevice_writeSetting(dev, key, value) != 0) {
+			status = 1;
+			fprintf(stderr, "WARNING: key set failed\n");
+		}
+	}
+
+	free(copied);
+
+	return status;
+}
+
 static void show_device_info(SoapySDRDevice *dev)
 {
 	size_t len = 0, i = 0;

--- a/src/convenience/convenience.h
+++ b/src/convenience/convenience.h
@@ -186,6 +186,16 @@ int verbose_device_search(char *s, SoapySDRDevice **devOut);
 int verbose_setup_stream(SoapySDRDevice *dev, SoapySDRStream **streamOut, size_t channel, const char *format);
 
 /*!
+ * Apply settings to device
+ *
+ * \param dev the device handle
+ * \param sdr_settings settings to apply
+ * \return 0 on success
+ */
+
+int verbose_settings(SoapySDRDevice *dev, const char *sdr_settings);
+
+/*!
  * Start redirecting stdout to stderr to avoid unwanted stdout emissions.
  * Applications should call this if they want to use stdout for their own output,
  * before verbose_device_start(), and optionally stop after configuring all settings.

--- a/src/rtl_sdr.c
+++ b/src/rtl_sdr.c
@@ -65,6 +65,7 @@ void usage(void)
 		"\t[-F output format, CU8|CS8|CS12|CS16|CF32 (default: CU8)]\n"
 		"\t[-S force sync output (default: async)]\n"
 		"\t[-D direct_sampling_mode, 0 (default/off), 1 (I), 2 (Q), 3 (no-mod)]\n"
+		"\t[-t SDR settings (ex: rfnotch_ctrl=false,dabnotch_ctrlb=true)]\n"
 		"\tfilename (a '-' dumps samples to stdout)\n\n");
 	exit(1);
 }
@@ -136,8 +137,9 @@ int main(int argc, char **argv)
 	uint32_t out_block_size = DEFAULT_BUF_LENGTH;
 	char const *input_format = SOAPY_SDR_CS16;
 	char const *output_format = SOAPY_SDR_CU8;
+	char *sdr_settings = NULL;
 
-	while ((opt = getopt(argc, argv, "d:f:g:c:a:s:b:n:p:D:SI:F:")) != -1) {
+	while ((opt = getopt(argc, argv, "d:f:g:c:a:s:b:n:p:D:SI:F:t:")) != -1) {
 		switch (opt) {
 		case 'd':
 			dev_query = optarg;
@@ -187,6 +189,9 @@ int main(int argc, char **argv)
             break;
 		case 'D':
 			direct_sampling = atoi(optarg);
+			break;
+		case 't':
+			sdr_settings = optarg;
 			break;
 		default:
 			usage();
@@ -299,6 +304,9 @@ int main(int argc, char **argv)
 	}
 	/* Reset endpoint before we start reading from it (mandatory) */
 	verbose_reset_buffer(dev);
+
+	if(sdr_settings)
+		verbose_settings(dev, sdr_settings);
 
 	if (true || sync_mode) {
 		fprintf(stderr, "Reading samples in sync mode...\n");


### PR DESCRIPTION
`SoapySDRUtil --probe` has a list of "Other Settings" for my SDRPlay 1A:
if_mode, iqcorr_ctrl, agc_setpoint, biasT_ctrl, rfnotch_ctrl, and dabnotch_ctrl

This lets me set those options when using the rx_sdr command line