### PR TITLE
rx_sdr added support for antenna selection

### DIFF
--- a/src/convenience/convenience.h
+++ b/src/convenience/convenience.h
@@ -141,13 +141,20 @@ int verbose_gain_set(SoapySDRDevice *dev, int gain);
 int verbose_gain_str_set(SoapySDRDevice *dev, char *gain_str);
 
 /*!
+* Set antenna and channel
+* \param dev the device handle
+* \param channel number of channel (0 is default)
+* \param antenna_str name of the antenna as reported by SoapySDR
+*/
+int verbose_antenna_str_set(SoapySDRDevice *dev, int channel, char *antenna_str);
+
+/*!
  * Set the frequency correction value for the device and report status on stderr.
  *
  * \param dev the device handle
  * \param ppm_error correction value in parts per million (ppm)
  * \return 0 on success
  */
-
 int verbose_ppm_set(SoapySDRDevice *dev, int ppm_error);
 
 /*!
@@ -164,12 +171,19 @@ int verbose_reset_buffer(SoapySDRDevice *dev);
  *
  * \param s a string to be parsed
  * \param devOut device output returned
+ * \return dev 0 if successful
+ */
+int verbose_device_search(char *s, SoapySDRDevice **devOut);
+
+/*!
+ * Open a stream on the pre-configured device
+ *
  * \param streamOut stream output returned
+ * \param channel channel to listen
  * \param format stream format (such as SOAPY_SDR_CS16)
  * \return dev 0 if successful
  */
-
-int verbose_device_search(char *s, SoapySDRDevice **devOut, SoapySDRStream **streamOut, const char *format);
+int verbose_setup_stream(SoapySDRDevice *dev, SoapySDRStream **streamOut, int channel, const char *format);
 
 /*!
  * Start redirecting stdout to stderr to avoid unwanted stdout emissions.

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -1368,7 +1368,8 @@ int main(int argc, char **argv)
 	ACTUAL_BUF_LENGTH = lcm_post[demod.post_downsample] * DEFAULT_BUF_LENGTH;
 
 	tmp_stdout = suppress_stdout_start();
-	verbose_device_search(dongle.dev_query, &dongle.dev, &dongle.stream, SOAPY_SDR_CS16);
+	verbose_device_search(dongle.dev_query, &dongle.dev);
+	verbose_stream_setup(dongle.dev, &dongle.stream, SOAPY_SDR_CS16);
 
 	if (!dongle.dev) {
 		fprintf(stderr, "Failed to open sdr device matching '%s'.\n", dongle.dev_query);

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -946,12 +946,13 @@ int main(int argc, char **argv)
 
 	fprintf(stderr, "Reporting every %i seconds\n", interval);
 
-	r = verbose_device_search(dev_query, &dev, &stream, SOAPY_SDR_CS16);
+	r = verbose_device_search(dev_query, &dev);
 
 	if (r != 0) {
 		fprintf(stderr, "Failed to open sdr device matching '%s'.\n", dev_query);
 		exit(1);
 	}
+	verbose_stream_setup(dev, &stream, SOAPY_SDR_CS16);
 
 	SoapySDRDevice_activateStream(dev, stream, 0, 0, 0);
 


### PR DESCRIPTION
This PR adds the option to select the soapy channel and the antenna to be used:

```
[-c channel number (ex: 0)]
[-a antenna (ex: 'Tuner 1 50 ohm')]
```

For the SDRPlay2 an example would be the following:

```
./rx_sdr -d "driver=sdrplay" -a 'Tuner 2 50 ohm' -c 0 -f 433920000 -F CS16 -n 10M -s 250000 -g 20 test-20db.cs16
```

**Implementation**
As the antenna has to be selected prior to the setup of the stream, the function `verbose_device_search` is split into the device search and the channel setup (`verbose_stream_setup`).
