### PR TITLE
Set antennas for all

### DIFF
--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -208,6 +208,8 @@ void usage(void)
 		"\t[-d device key/value query (ex: 0, 1, driver=rtlsdr, driver=hackrf)]\n"
 		"\t[-g tuner gain(s) (ex: 20, 40, LNA=40,VGA=20,AMP=0)]\n"
 		"\t[-w tuner_bandwidth (default: automatic. enables offset tuning)]\n"
+		"\t[-c channel number (ex: 0)]\n"
+		"\t[-a antenna (ex: 'Tuner 1 50 ohm')]\n"
 		"\t[-l squelch_level (default: 0/off)]\n"
 		"\t[-L N  prints levels every N calculations]\n"
 		"\t	output are comma separated values (csv):\n"
@@ -1207,17 +1209,25 @@ int main(int argc, char **argv)
 	struct sigaction sigact;
 #endif
 	int custom_ppm = 0;
-	int opt;
+	int r, opt;
 	int timeConstant = 75; /* default: U.S. 75 uS */
 	int rtlagc = 0;
+	int channel = 0;
+	char *antenna_str = NULL;
 	dongle_init(&dongle);
 	demod_init(&demod);
 	output_init(&output);
 	controller_init(&controller);
 	dongle.dev_query = "";
 
-	while ((opt = getopt(argc, argv, "d:f:g:s:b:l:L:o:t:r:p:E:q:F:A:M:c:h:w:v")) != -1) {
+	while ((opt = getopt(argc, argv, "a:C:d:f:g:s:b:l:L:o:t:r:p:E:q:F:A:M:c:h:w:v")) != -1) {
 		switch (opt) {
+		case 'a':
+			antenna_str = optarg;
+			break;
+		case 'C':
+			channel = (int)atoi(optarg);
+			break;
 		case 'd':
 			dongle.dev_query = optarg;
 			break;
@@ -1401,6 +1411,14 @@ int main(int argc, char **argv)
 		demod.deemph_a = (int)round(1.0/((1.0-exp(-1.0/(demod.rate_out * tc)))));
 		if (verbosity)
 			fprintf(stderr, "using wbfm deemphasis filter with time constant %d us\n", timeConstant );
+	}
+
+	/* Set the antenna */
+	if (NULL != antenna_str) {
+		r = verbose_antenna_str_set(dongle.dev, channel, antenna_str);
+		if (r != 0) {
+			fprintf(stderr, "Failed to set antenna");
+		}
 	}
 
 	/* Set the tuner gain */

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -208,7 +208,7 @@ void usage(void)
 		"\t[-d device key/value query (ex: 0, 1, driver=rtlsdr, driver=hackrf)]\n"
 		"\t[-g tuner gain(s) (ex: 20, 40, LNA=40,VGA=20,AMP=0)]\n"
 		"\t[-w tuner_bandwidth (default: automatic. enables offset tuning)]\n"
-		"\t[-c channel number (ex: 0)]\n"
+		"\t[-C channel number (ex: 0)]\n"
 		"\t[-a antenna (ex: 'Tuner 1 50 ohm')]\n"
 		"\t[-l squelch_level (default: 0/off)]\n"
 		"\t[-L N  prints levels every N calculations]\n"

--- a/src/rtl_power.c
+++ b/src/rtl_power.c
@@ -128,6 +128,8 @@ void usage(void)
 		"\t (buggy if a full sweep takes longer than the interval)\n"
 		"\t[-1 enables single-shot mode (default: off)]\n"
 		"\t[-e exit_timer (default: off/0)]\n"
+		"\t[-C channel number (ex: 0)]\n"
+		"\t[-a antenna (ex: 'Tuner 1 50 ohm')]\n"
 		//"\t[-s avg/iir smoothing (default: avg)]\n"
 		//"\t[-t threads (default: 1)]\n"
 		"\t[-d device key/value query (ex: 0, 1, driver=rtlsdr, driver=hackrf)]\n"
@@ -839,10 +841,18 @@ int main(int argc, char **argv)
 	char t_str[50];
 	struct tm cal_time = {0};
 	double (*window_fn)(int, int) = rectangle;
+	int channel = 0;	
+	char *antenna_str = NULL;
 	freq_optarg = "";
 
-	while ((opt = getopt(argc, argv, "f:i:s:t:d:g:p:e:w:c:F:1PD:OS:R:h")) != -1) {
+	while ((opt = getopt(argc, argv, "a:C:f:i:s:t:d:g:p:e:w:c:F:1PD:OS:R:h")) != -1) {
 		switch (opt) {
+		case 'a':
+			antenna_str = optarg;
+			break;
+		case 'C':
+			channel = (int)atoi(optarg);
+			break;
 		case 'f': // lower:upper:bin_size
 			freq_optarg = strdup(optarg);
 			f_set = 1;
@@ -953,6 +963,15 @@ int main(int argc, char **argv)
 		fprintf(stderr, "Failed to open sdr device matching '%s'.\n", dev_query);
 		exit(1);
 	}
+
+	/* Set the antenna */
+	if (NULL != antenna_str) {
+		r = verbose_antenna_str_set(dev, channel, antenna_str);
+		if(r != 0){
+			fprintf(stderr, "Failed to set antenna");
+		}
+	}
+
 	verbose_setup_stream(dev, &stream, 0, SOAPY_SDR_CS16);
 
 	SoapySDRDevice_activateStream(dev, stream, 0, 0, 0);

--- a/src/rtl_sdr.c
+++ b/src/rtl_sdr.c
@@ -93,8 +93,8 @@ int main(int argc, char **argv)
 	char *filename = NULL;
 	int r, opt;
 	char *gain_str = NULL;
-  int channel = 0;
-  char *antenna_str = NULL;
+	int channel = 0;
+	char *antenna_str = NULL;
 	int ppm_error = 0;
 	int sync_mode = 0;
 	int direct_sampling = 0;
@@ -230,6 +230,7 @@ int main(int argc, char **argv)
 		verbose_gain_str_set(dev, gain_str);
 	}
 
+	/* Set the antenna */
 	if (NULL != antenna_str){
 		r = verbose_antenna_str_set(dev, channel, antenna_str);
 		if(r != 0){


### PR DESCRIPTION
- Adds channel and antenna_str vars
- Calls verbose_antenna_str_set when necessary
- Touches up some formatting

One thing to note that channel option case changes as `rtl_fm` and `rtl_power` already use lower-case `c` options.