### PR TITLE
Fix gain mode (rtlsdr)

### DIFF
--- a/src/convenience/convenience.c
+++ b/src/convenience/convenience.c
@@ -239,14 +239,15 @@ int verbose_auto_gain(SoapySDRDevice *dev, size_t channel)
 {
 	int r;
 	r = 0;
-	/* TODO: not bridged, https://github.com/pothosware/SoapyRTLSDR/search?utf8=✓&q=rtlsdr_set_tuner_gain_mode
-	r = rtlsdr_set_tuner_gain_mode(dev, 0);
-	if (r != 0) {
-		fprintf(stderr, "WARNING: Failed to set tuner gain.\n");
-	} else {
+	if (SoapySDRDevice_hasGainMode(dev, SOAPY_SDR_RX, channel)) {
+		r = SoapySDRDevice_setGainMode(dev, SOAPY_SDR_RX, channel, /*automatic*/ true);
+		if (r != 0) {
+			fprintf(stderr, "WARNING: Failed to enable auto gain: %s\n", SoapySDRDevice_lastError());
+			return r;
+		}
 		fprintf(stderr, "Tuner gain set to automatic.\n");
+		return 0;
 	}
-	*/
 
 	// Per-driver hacks TODO: clean this up
 	char *driver = SoapySDRDevice_getDriverKey(dev);
@@ -288,13 +289,13 @@ int verbose_gain_str_set(SoapySDRDevice *dev, char *gain_str, size_t channel)
 {
 	int r = 0;
 
-	/* TODO: manual gain mode
-	r = rtlsdr_set_tuner_gain_mode(dev, 1);
-	if (r < 0) {
-		fprintf(stderr, "WARNING: Failed to enable manual gain.\n");
-		return r;
+	if (SoapySDRDevice_hasGainMode(dev, SOAPY_SDR_RX, channel)) {
+		r = SoapySDRDevice_setGainMode(dev, SOAPY_SDR_RX, channel, /*automatic*/ false);
+		if (r != 0) {
+			fprintf(stderr, "WARNING: Failed to enable manual gain: %s\n", SoapySDRDevice_lastError());
+			return r;
+		}
 	}
-	*/
 
 	if (strchr(gain_str, '=')) {
 		// Set each gain individually (more control)

--- a/src/rtl_fm.c
+++ b/src/rtl_fm.c
@@ -225,8 +225,6 @@ void usage(void)
 		"\t	rdc:    enable dc blocking filter on raw I/Q data at capture rate\n"
 		"\t	adc:    enable dc blocking filter on demodulated audio\n"
 		"\t	dc:     same as adc\n"
-		"\t	rtlagc: enable rtl2832's digital agc (default: off)\n"
-		"\t	agc:    same as rtlagc\n"
 		"\t	deemp:  enable de-emphasis filter\n"
 		"\t	direct: enable direct sampling (bypasses tuner, uses rtl2832 xtal)\n"
 		"\t	no-mod: enable no-mod direct sampling\n"
@@ -1213,7 +1211,6 @@ int main(int argc, char **argv)
 	int custom_ppm = 0;
 	int r, opt;
 	int timeConstant = 75; /* default: U.S. 75 uS */
-	int rtlagc = 0;
 	char *antenna_str = NULL;
 	dongle_init(&dongle);
 	demod_init(&demod);
@@ -1292,8 +1289,6 @@ int main(int argc, char **argv)
 				dongle.direct_sampling = 3;}
 			if (strcmp("offset",  optarg) == 0) {
 				dongle.offset_tuning = 1;}
-			if (strcmp("rtlagc", optarg) == 0 || strcmp("agc", optarg) == 0) {
-				rtlagc = 1;}
 			if (strcmp("zero", optarg) == 0) {
 				demod.squelch_zero = 1;}
 			if (strcmp("wav",  optarg) == 0) {
@@ -1428,8 +1423,6 @@ int main(int argc, char **argv)
 	} else {
 		verbose_gain_str_set(dongle.dev, dongle.gain_str, dongle.channel);
 	}
-
-	SoapySDRDevice_setGainMode(dongle.dev, SOAPY_SDR_RX, dongle.channel, rtlagc);
 
 	if (custom_ppm) verbose_ppm_set(dongle.dev, dongle.ppm_error, dongle.channel);
 


### PR DESCRIPTION
Fix `rx_fm` not working with rtlsdr (fixes #90 )

1. `SoapySDRDevice_setGainMode` was called after `SoapySDRDevice_setGain`, that seems to reset gain to 0. Likely due to https://github.com/steve-m/librtlsdr/blob/619ac3186ea0ffc092615e1f59f7397e5e6f668c/src/librtlsdr.c#L258C1-L261C2 :  
```
int r820t_set_gain_mode(void *dev, int manual) {
	rtlsdr_dev_t* devt = (rtlsdr_dev_t*)dev;
	return r82xx_set_gain(&devt->r82xx_p, manual, 0);
}
```
i.e. gain value is reset to 0 when  `rtlsdr_set_tuner_gain_mode` is called
2.  Remove rtlagc option as it's not needed anymore.


With these changes I get identical output from `rtl_fm` and `rx_fm` with both auto and manual gains e.g. 

```
rtl_fm -vvvv   -f 88.5M -M wbfm -r 48k  | play -r 48k -t raw -e s -b 16 -c 1 -V1 -
rx_fm -vvvv   -f 88.5M -M wbfm -r 48k  | play -r 48k -t raw -e s -b 16 -c 1 -V1 -

or
 
rtl_fm  -vvvv   -f 88.5M -M wbfm -r 48k -g 30  | play -r 48k -t raw -e s -b 16 -c 1 -V1 -
rx_fm -vvvv   -f 88.5M -M wbfm -r 48k -g 30  | play -r 48k -t raw -e s -b 16 -c 1 -V1 -
```